### PR TITLE
chore: Add .gitattributes to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf


### PR DESCRIPTION
This PR introduces a .gitattributes file to enforce consistent line endings across the project. This resolves potential issues between different operating systems (Windows CRLF vs. Unix LF).